### PR TITLE
redirect from old YAML page

### DIFF
--- a/content/en/docs/apps/yaml-definition.md
+++ b/content/en/docs/apps/yaml-definition.md
@@ -3,6 +3,7 @@ title : "App YAML definition"
 weight: 450
 aliases:
   - /darcy/darcy-cloud/applications-doc/app-doc-yaml
+  - /docs/cloud/portal/ai-explorer-app/app-yaml/
 ---
 
 Darcy Cloud uses [Eclipse ioFog](https://iofog.org) under the covers to deploy and manage

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -1,6 +1,8 @@
 <footer class="footer">
   <div class="footer-layout">
-    <img src="/images/footer/foot-logo-darcy.png" loading="lazy" alt="">
+    <a href="https:www.darcy.ai">
+      <img src="/images/footer/foot-logo-darcy.png" loading="lazy" alt="">
+    </a>
     <div class="footer-nav">
       <div id="w-node-c9636e96-9447-38e2-ab75-14632ebdb522-2ebdb50e" class="footer-navstack">
         <h4 class="footer-head">Developers</h4>
@@ -42,7 +44,9 @@
           <img src="/images/footer/Linkedin.png" loading="lazy" alt="" class="social-icon">
         </a>
       </div>
-      <img src="/images/footer/foot-logo-edgeworx.png" loading="lazy" width="150" class="logo" alt="">
+      <a href="https:www.darcy.ai">
+        <img src="/images/footer/foot-logo-edgeworx.png" loading="lazy" width="150" class="logo" alt="">
+      </a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
## Summary

added redirect for old YAML url

footer logos (Darcy, Edgeworx) now link to Darcy.ai

## Basic example

Include a basic example, screenshots, or links.

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [ ] Verify that your changes build locally. Passes:
  - `npm run test`
  - `npm run build:preview` followed by `npm run lint`
- [ ] Create a Pull Request (follow the [GitHub flow](https://guides.github.com/introduction/flow/)) and [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)

