### PR TITLE
REmove fix me, fix link color in alerts

### DIFF
--- a/assets/scss/common/_fonts.scss
+++ b/assets/scss/common/_fonts.scss
@@ -134,7 +134,7 @@
 @font-face {
   font-family: Gilroy;
   font-style: normal;
-  font-weight: 700;
+  font-weight: 800;
   src:
     local(""),
     url("fonts/Gilroy/Gilroy-ExtraBold.woff2") format("woff2"),
@@ -145,7 +145,7 @@
 @font-face {
   font-family: Gilroy;
   font-style: italic;
-  font-weight: 700;
+  font-weight: 800;
   src:
     local(""),
     url("fonts/Gilroy/Gilroy-ExtraBoldItalic.woff2") format("woff2"),

--- a/assets/scss/components/_alerts.scss
+++ b/assets/scss/components/_alerts.scss
@@ -5,6 +5,7 @@
 
   a {
     color: inherit;
+    text-decoration: underline;
   }
 }
 
@@ -43,10 +44,6 @@
 .alert-primary {
   color: $white;
   background-color: $primary;
-}
-
-.alert a {
-  text-decoration: underline;
 }
 
 .alert-primary .alert-link {

--- a/assets/scss/components/_alerts.scss
+++ b/assets/scss/components/_alerts.scss
@@ -2,6 +2,10 @@
   font-family: Gilroy, sans-serif;
   font-size: $font-size-md;
   border-radius: 4px;
+
+  a {
+    color: inherit;
+  }
 }
 
 .alert-icon {

--- a/assets/scss/components/_syntax.scss
+++ b/assets/scss/components/_syntax.scss
@@ -8,55 +8,69 @@ Based on Ascetic by (c) Ivan Sagalaev <Maniac@SoftwareManiacs.Org>
   display: block;
   overflow-x: auto;
   padding: 1.25rem 1.5rem;
-  background: $edgeneutral-05;
-  color: $body-color;
+  background: $edgeneutral-5;
+  color: white!important;
 }
 
-.hljs-string,
-.hljs-variable,
-.hljs-template-variable,
-.hljs-symbol,
-.hljs-bullet,
+.hljs-built_in,
+.hljs-selector-tag,
 .hljs-section,
-.hljs-addition,
-.hljs-attribute,
 .hljs-link {
   color: $darcy-blue-dark;
 }
 
+.hljs-keyword {
+  color: #ff79c6;
+}
+
+.hljs,
+.hljs-subst {
+  color: #f8f8f2;
+}
+
+.hljs-title,
+.hljs-attr,
+.hljs-meta-keyword {
+  font-style: italic;
+  color: #50fa7b;
+}
+
+.hljs-string,
+.hljs-meta,
+.hljs-name,
+.hljs-type,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-addition,
+.hljs-variable,
+.hljs-template-tag,
+.hljs-template-variable {
+  color: #f1fa8c;
+}
+
 .hljs-comment,
 .hljs-quote,
-.hljs-meta,
 .hljs-deletion {
-  color: #888;
+  color: #6272a4;
 }
 
 .hljs-keyword,
 .hljs-selector-tag,
+.hljs-literal,
+.hljs-title,
 .hljs-section,
-.hljs-name,
+.hljs-doctag,
 .hljs-type,
+.hljs-name,
 .hljs-strong {
   font-weight: bold;
 }
 
+.hljs-literal,
+.hljs-number {
+  color: #bd93f9;
+}
+
 .hljs-emphasis {
   font-style: italic;
-}
-
-[data-dark-mode] body .hljs {
-  background: $body-overlay-dark;
-  color: $body-color-dark;
-}
-
-[data-dark-mode] body .hljs-string,
-[data-dark-mode] body .hljs-variable,
-[data-dark-mode] body .hljs-template-variable,
-[data-dark-mode] body .hljs-symbol,
-[data-dark-mode] body .hljs-bullet,
-[data-dark-mode] body .hljs-section,
-[data-dark-mode] body .hljs-addition,
-[data-dark-mode] body .hljs-attribute,
-[data-dark-mode] body .hljs-link {
-  color: $darcy-blue-dark;
 }

--- a/content/en/docs/cloud/adding-nodes/_index.md
+++ b/content/en/docs/cloud/adding-nodes/_index.md
@@ -23,10 +23,9 @@ We recommend the following components for processing real-time video at the edge
 | Raspberry Pi4 | Any Pi4 camera | 5.1V * 3.5A power | Coral Accelerator|
 | [Learn More](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/)  | [Learn More](https://www.amazon.com/gp/product/B07SN8GYGD)  | [Learn More](https://www.amazon.com/CanaKit-Raspberry-Power-Supply-USB-C/dp/B07TYQRXTK/ref=sr_1_3?crid=2BGU12U80RGNV&keywords=canakit+power+supply&qid=1655761341&sprefix=cana+kit+power+supply%2Caps%2C125&sr=8-3)  | [Learn More](https://coral.ai/products/accelerator/)
 
-Note: The Google Coral Dev board should also offer good AI performance but hasn't been tested with Darcy AI yet.
-
-FIXME: ^^ is this correct?
-
+{{<alert style="info">}}
+The Google Coral Dev board should also offer good AI performance but hasn't been tested with Darcy AI yet.
+{{</alert>}}
 ## More compatible edge boards
 
 Darcy Cloud is compatible with many Linux edge boards:

--- a/content/en/docs/cloud/adding-nodes/_index.md
+++ b/content/en/docs/cloud/adding-nodes/_index.md
@@ -26,6 +26,7 @@ We recommend the following components for processing real-time video at the edge
 {{<alert style="info">}}
 The Google Coral Dev board should also offer good AI performance but hasn't been tested with Darcy AI yet.
 {{</alert>}}
+
 ## More compatible edge boards
 
 Darcy Cloud is compatible with many Linux edge boards:


### PR DESCRIPTION
## Summary

Brief explanation of the proposed changes.

Misc fixes for docs:

- Links open in a new tab
- Code blocks are dark themed (can update colors of syntax highlight later on, I copied a dark theme from the net)
- Removed fix me from adding nodes
- Updated links inside alerts to be more visibles

## Basic example

Include a basic example, screenshots, or links.

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [ ] Verify that your changes build locally. Passes:
  - `npm run test`
  - `npm run build:preview` followed by `npm run lint`
- [ ] Create a Pull Request (follow the [GitHub flow](https://guides.github.com/introduction/flow/)) and [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)

