### PR TITLE
Segment track docs pages and external links clicks

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -13,4 +13,4 @@ See https://github.com/bep/portable-hugo-links/blob/master/layouts/_default/_mar
 {{- with $url.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
 {{- with .Page.GetPage $url.Path }}{{ $link = printf "%s%s" .RelPermalink $fragment }}{{ end }}{{ end -}}
 {{- end -}}
-<a href="{{ $link | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $isRemote }} target="_blank"{{ end }}>{{ .Text | safeHTML }}</a>
+<a href="{{ $link | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if $isRemote }} onclick="trackExternalLink('{{ $link | safeURL }}')" target="_blank"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -1,4 +1,7 @@
 {{ define "main" }}
+<script>
+  window.analytics.page("Docs", "{{ .Title }}", { path: window.location.pathname })
+</script>
 {{ $currentSection := .CurrentSection }}
 {{ $currentPage := .}}
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,4 +1,7 @@
 {{ define "main"}}
+<script>
+  window.analytics.page("Docs", "Home", { path: window.location.pathname })
+</script>
 <div class="row flex-xl-nowrap">
   <div class="col-lg-5 col-xl-4 docs-sidebar d-none d-lg-block">
     <nav {{ if eq .Site.Params.menu.section.collapsibleSidebar false }}id="sidebar-default" {{ end }}class="docs-links" aria-label="Main navigation">

--- a/layouts/partials/head/analytics.html
+++ b/layouts/partials/head/analytics.html
@@ -16,6 +16,14 @@
       analytics.load("{{- . -}}");
       analytics.page();
     }}();
+
+    function trackExternalLink(dest) {
+      window.analytics.track("Docs clicked external link", { dest });
+    }
+
+    function trackLogin() {
+      window.analytics.track("Docs clicked Login", { src: window.location.pathname });
+    }
   </script>
 {{ end -}}
 

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -82,7 +82,7 @@
     <div class="darcyai menu-container d-none d-md-grid">
       <!--<a class="darcyai home-link" href="https://darcy.ai" alt="Darcy.ai">Products</a>-->
       <!--<a class="darcyai dev-link" href="/">Developers</a>-->
-      <a class="darcyai login-link" href="https://cloud.darcy.ai" alt="Portal login">Log in</a>
+      <a class="darcyai login-link" href="https://cloud.darcy.ai" alt="Portal login" onclick="trackLogin()">Log in</a>
     </div>
     <!-- {{ if .Site.Params.options.darkMode -}}
     <button id="mode" class="btn btn-link order-md-1" type="button" aria-label="Toggle user interface mode">


### PR DESCRIPTION
## Summary

Add segment event for each page load, external links being opened and login button being pressed

## Basic example

Include a basic example, screenshots, or links.

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [ ] Verify that your changes build locally. Passes:
  - `npm run test`
  - `npm run build:preview` followed by `npm run lint`
- [ ] Create a Pull Request (follow the [GitHub flow](https://guides.github.com/introduction/flow/)) and [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)

