### PR TITLE
Updated pip install commands in Darcy AI build doc

### DIFF
--- a/content/en/docs/guides/build.md
+++ b/content/en/docs/guides/build.md
@@ -68,16 +68,16 @@ or [windows (coming soon)](https://stackoverflow.com/questions/5087831/how-shoul
 
 ```bash
 # Install OpenCV
-pip install opencv-python>=4.5.5.64
+pip install "opencv-python>=4.5.5.64"
 
 # Install the Pillow library
-pip install Pillow>=8.3.2
+pip install "Pillow>=8.3.2"
 
 # Install the Numpy library
-pip install numpy>=1.22.4
+pip install "numpy>=1.22.4"
 
 # Install the Imutils library
-pip install imutils>=0.5.4
+pip install "imutils>=0.5.4"
 
 # Install the DarcyAI Engine
 pip install darcyai


### PR DESCRIPTION
## Summary
Some shell environments treat `>` sign as an operand so commands like `pip install some_library>=1.0.0` fails. So the version and library name need to be inside quotes.

## Basic example
`pip install "some_library>=1.0.0"`
