### PR TITLE
[sc-16286] Nav broken by tab content

### DIFF
--- a/layouts/partials/main/docs-navigation.html
+++ b/layouts/partials/main/docs-navigation.html
@@ -56,6 +56,11 @@ Note:
             {{continue}}
         {{end}}
 
+        {{ if  eq $item.Title "" }}
+            {{/* If the title is empty, we definitely don't want it showing up */}}
+            {{continue}}
+        {{end}}
+
         {{ $p.Scratch.Set "nextSib" $item}}
         {{ break }}
     {{end}}
@@ -89,6 +94,11 @@ Note:
             {{continue}}
         {{end}}
 
+        {{ if  eq $item.Title "" }}
+            {{/* If the title is empty, we definitely don't want it showing up */}}
+            {{continue}}
+        {{end}}
+
         {{ $p.Scratch.Set "nextAunt" $item}}
         {{ break }}
       {{end}}
@@ -115,6 +125,11 @@ Note:
 
               {{/* If it's an external link, we don't want it to show up in nav */}}
               {{continue}}
+            {{end}}
+
+            {{ if  eq $item.Title "" }}
+                {{/* If the title is empty, we definitely don't want it showing up */}}
+                {{continue}}
             {{end}}
 
             {{ if eq $p.RelPermalink $item.RelPermalink }}
@@ -144,8 +159,12 @@ Note:
       {{ range $i, $item := $parentSection.Pages }}
 
           {{ with $item.Params.externalLink}}
-
               {{/* If it's an external link, we don't want it to show up in nav */}}
+              {{continue}}
+          {{end}}
+
+          {{ if  eq $item.Title "" }}
+              {{/* If the title is empty, we definitely don't want it showing up */}}
               {{continue}}
           {{end}}
 


### PR DESCRIPTION
## Summary

[sc-16286]

Content (in `.md` files) that is included by the tabs shortcode is also appearing in the nav arrows, which we don't want. These `.md` files typically don't have a title, so we can exclude them just by testing for the absence of a title.


## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [ ] Run `npm run test` locally.
- [ ] Create a Pull Request (follow the [GitHub flow](https://guides.github.com/introduction/flow/)) and [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [ ] Verify any structural/CSS changes on all screen sizes (if relevant)

