### PR TITLE
Adding latest Linux script install to docs

### DIFF
--- a/content/en/docs/cloud/edgectl/_index.md
+++ b/content/en/docs/cloud/edgectl/_index.md
@@ -59,7 +59,7 @@ scoop install edgectl
 On Linux distros, use `get-edgectl.bash`:
 
 ```bash
-curl https://cloud.darcy.ai/get-edgectl.bash | bash
+curl -s https://cloud.darcy.ai/get-edgectl.bash | sudo bash
 ```
 
 {{% /tab %}}

--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -1,5 +1,5 @@
 {
-  "skip": "(github.com\\/darcyai\\/docs|linkedin.com\\/company\\/edgeworxio|api.darcy.ai)",
+  "skip": "(github.com\\/darcyai\\/docs|linkedin.com\\/company\\/edgeworxio|api.darcy.ai|twitter.com\\/EdgeworxIO)",
   "timeout:": 2000,
   "retryErrors": true,
   "retryErrorsJitter": true,


### PR DESCRIPTION
## Summary

When we updated our main Cloud page with latest CLI, we did not do it in the docs. 

[sc-18386]

## Motivation

To fix  our mistake. 

## Checks

- [ ] Run `npm run test` locally.
- [ ] Create a Pull Request (follow the [GitHub flow](https://guides.github.com/introduction/flow/)) and [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [ ] Verify any structural/CSS changes on all screen sizes (if relevant)

