### PR TITLE
Fix header color to match website

### DIFF
--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -33,6 +33,7 @@ $edgeneutral-2: #a9b2bc;
 $edgeneutral-3: #0a415e;
 $edgeneutral-4: #012d44;
 $edgeneutral-5: #002131;
+$edgeneutral-6: #181F22;
 $edgeworx-blue: #0195d9;
 $edgeworx-blue-dark: #5ac8fa;
 $edgeworx-red: #fd575d;

--- a/assets/scss/common/_variables.scss
+++ b/assets/scss/common/_variables.scss
@@ -33,7 +33,7 @@ $edgeneutral-2: #a9b2bc;
 $edgeneutral-3: #0a415e;
 $edgeneutral-4: #012d44;
 $edgeneutral-5: #002131;
-$edgeneutral-6: #181F22;
+$edgeneutral-6: #181f22;
 $edgeworx-blue: #0195d9;
 $edgeworx-blue-dark: #5ac8fa;
 $edgeworx-red: #fd575d;

--- a/assets/scss/layouts/_header.scss
+++ b/assets/scss/layouts/_header.scss
@@ -101,7 +101,7 @@
 
 .navbar {
   z-index: 1000;
-  background: $edgeneutral-5 0% 0% no-repeat padding-box;
+  background: $edgeneutral-6 0% 0% no-repeat padding-box;
   height: 64px;
 
   /*


### PR DESCRIPTION
## Summary

Brief explanation of the proposed changes.
- add a new color variable (edge neutral 6=darkest blue)
- assign new color variable to header BG color

Link to Shortcut story.

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [ ] Run `npm run test` locally.
- [ ] Create a Pull Request (follow the [GitHub flow](https://guides.github.com/introduction/flow/)) and [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [ ] Verify any structural/CSS changes on all screen sizes (if relevant)

