### PR TITLE
Fix - SC-20828 - Restoring proper indentation on codeblock

### DIFF
--- a/assets/scss/components/_code.scss
+++ b/assets/scss/components/_code.scss
@@ -16,11 +16,6 @@ tab-pane code {
   padding: 0.125rem 0.25rem;
 }
 
-p code,
-div code {
-  white-space: nowrap;
-}
-
 pre.chroma {
   margin: 1.5rem 0;
 }


### PR DESCRIPTION
Removed `nowrap` from code block formatting to restore proper indentation.

[SC-20828]